### PR TITLE
[#17] Relax sub-entity `rel` requirement, default to ["item"]

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ A set of key-value pairs that describe the state of an entity.  In JSON Siren, t
 
 A collection of related sub-entities. Optional.
 
-If a sub-entity contains an `href` value, it should be treated as an embedded link.  Clients may choose to optimistically load embedded links.  If no `href` value exists, the sub-entity is an embedded entity representation that contains all the characteristics of a typical entity. Sub-entities SHOULD contain an array of `rel` values to describe its relationship to the parent. If no `rel` value is supplied, `["item"]` is assumed.
+If a sub-entity contains an `href` value, it should be treated as an embedded link.  Clients may choose to optimistically load embedded links.  If no `href` value exists, the sub-entity is an embedded entity representation that contains all the characteristics of a typical entity. Sub-entities SHOULD contain an array of `rel` values to describe their relationship with the parent. If no `rel` value is supplied, `["item"]` is assumed.
 
 
 ####`links`

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ All examples in this document are in the JSON Siren format.
 
 An Entity is a URI-addressable resource that has properties and actions associated with it.  It may contain sub-entities and navigational links.
 
-Root entities and sub-entities that are embedded representations MUST contain a ```links``` collection with at least one item contain a ```rel``` value of ```self``` and an ```href``` attribute with a value of the entity's URI.
+Root entities and sub-entities that are embedded representations SHOULD contain a ```links``` collection with at least one item containing a ```rel``` value of ```self``` and an ```href``` attribute with a value of the entity's URI.
 
 Sub-entities that are embedded links MUST contain an ```href``` attribute with a value of its URI.
 
@@ -86,7 +86,7 @@ A set of key-value pairs that describe the state of an entity.  In JSON Siren, t
 
 ####```entities```
 
-A collection of related sub-entities.  If a sub-entity contains an ```href``` value, it should be treated as an embedded link.  Clients may choose to optimistically load embedded links.  If no ```href``` value exists, the sub-entity is an embedded entity representation that contains all the characteristics of a typical entity.  One difference is that a sub-entity MUST contain a ```rel``` attribute to describe its relationship to the parent entity.
+A collection of related sub-entities.  If a sub-entity contains an ```href``` value, it should be treated as an embedded link.  Clients may choose to optimistically load embedded links.  If no ```href``` value exists, the sub-entity is an embedded entity representation that contains all the characteristics of a typical entity.
 
 In JSON Siren, this is represented as an array.  Optional.
 
@@ -124,7 +124,7 @@ The URI of the linked sub-entity.  Required.
 
 ####Embedded Representation
 
-Embedded sub-entity representations retain all the characteristics of a standard entity, but MUST also contain a ```rel``` attribute describing the relationship of the sub-entity to its parent.
+Embedded sub-entity representations retain all the characteristics of a standard entity.
 
 ###Classes vs. Relationships
 

--- a/README.md
+++ b/README.md
@@ -89,9 +89,10 @@ A set of key-value pairs that describe the state of an entity.  In JSON Siren, t
 
 ####`entities`
 
-A collection of related sub-entities.  If a sub-entity contains an `href` value, it should be treated as an embedded link.  Clients may choose to optimistically load embedded links.  If no `href` value exists, the sub-entity is an embedded entity representation that contains all the characteristics of a typical entity.
+A collection of related sub-entities. Optional.
 
-In JSON Siren, this is represented as an array.  Optional.
+If a sub-entity contains an `href` value, it should be treated as an embedded link.  Clients may choose to optimistically load embedded links.  If no `href` value exists, the sub-entity is an embedded entity representation that contains all the characteristics of a typical entity. Sub-entities SHOULD contain an array of `rel` values to describe its relationship to the parent. If no `rel` value is supplied, `["item"]` is assumed.
+
 
 ####`links`
 
@@ -119,7 +120,7 @@ Describes the nature of an entity's content based on the current representation.
 
 #####`rel`
 
-Defines the relationship of the sub-entity to its parent, per [Web Linking (RFC5899)](http://tools.ietf.org/html/rfc5988).  MUST be an array of strings.  Required.
+Defines the relationship of the sub-entity to its parent, per [Web Linking (RFC5899)](http://tools.ietf.org/html/rfc5988).  MUST be an array of strings. When omitted, the default value is `["item"]`. Optional.
 
 #####`href`
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,6 @@ All examples in this document are in the JSON Siren format.
 
 An Entity is a URI-addressable resource that has properties and actions associated with it.  It may contain sub-entities and navigational links.
 
-
 Root entities and sub-entities that are embedded representations SHOULD contain a `links` collection with at least one item contain a `rel` value of `self` and an `href` attribute with a value of the entity's URI.
 
 Sub-entities that are embedded links MUST contain an `href` attribute with a value of its URI.


### PR DESCRIPTION
Changes as per hangout discussion and [https://github.com/kevinswiber/siren/issues/17](issue #17).