### PR TITLE
It should be "title" instead of "class" for Actions description.

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Actions show available behaviors an entity exposes.
 
 A string that identifies the action to be performed.  Required.
 
-###`class`
+###`title`
 
 Describes the nature of an action based on the current representation.  Possible values are implementation-dependent and should be documented.  MUST be an array of strings.  Optional.
 


### PR DESCRIPTION
Hi, I just noticed that "title" key for "actions" in the example is currently described as "class" like below.

https://github.com/kevinswiber/siren#example
https://github.com/kevinswiber/siren#class-2

Please be sure to check this out whether its correct or not.
By the way, I really love this hypermedia format.
