### PR TITLE
Removing button and image.

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ The input type of the field. This may include any of the following [input types]
 `hidden`, `text`, `search`, `tel`, `url`, `email`, `password`, `datetime`, `date`,
 `month`, `week`, `time`, `datetime-local`, 
 `number`, `range`, `color`, `checkbox`,
-`radio`, `file`, `image`, `button`
+`radio`, `file` 
 
 When missing, the default value is `text`.  Serialization of these fields will depend on the value of the action's `type` attribute. See [`type`](#type) under Actions, above. Optional.
 


### PR DESCRIPTION
Remove the `button` and the `image` input types for action fields.

In the context of sending an HTTP request it seems weird to have these as available input types. They can't really be set as parameters in a request body.

See here for reference: http://www.w3.org/TR/html5/single-page.html#the-input-element