### PR TITLE
Field Names Must Be Unique

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Fields represent controls inside of actions.  They may contain these attributes:
 
 ####name
 
-A name describing the control.  Required.
+A name describing the control.  Field names MUST be unique within the set of fields for an action. The behaviour of clients when parsing a Siren document that violates this constraint is undefined.  Required.
 
 ###`class`
 


### PR DESCRIPTION
Currently the spec is silent on whether field names within an action should be unique. [Some clients already assume they should be unique](https://groups.google.com/d/msg/siren-hypermedia/cwyIzM4jwOc/E01SxWV0BQAJ).