### PR TITLE
Rel value constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Describes the nature of an entity's content based on the current representation.
 
 #####`rel`
 
-Defines the relationship of the sub-entity to its parent, per [Web Linking (RFC5988)](http://tools.ietf.org/html/rfc5988).  MUST be an array of strings.  Required.
+Defines the relationship of the sub-entity to its parent, per [Web Linking (RFC5988)](http://tools.ietf.org/html/rfc5988) and [Link Relations](http://www.iana.org/assignments/link-relations/link-relations.xhtml).  MUST be an array of strings.  Required.
 
 #####`href`
 
@@ -152,7 +152,7 @@ Links may contain the following attributes:
 
 ###`rel`
 
-Defines the relationship of the link to its entity, per [Web Linking (RFC5988)](http://tools.ietf.org/html/rfc5988).  MUST be an array of strings. Required.
+Defines the relationship of the link to its entity, per [Web Linking (RFC5988)](http://tools.ietf.org/html/rfc5988) and [Link Relations](http://www.iana.org/assignments/link-relations/link-relations.xhtml).  MUST be an array of strings. Required.
 
 ###`class`
 

--- a/siren.schema.json
+++ b/siren.schema.json
@@ -64,7 +64,7 @@
                     "description": "Defines the relationship of the sub-entity to its parent, per Web Linking (RFC5899).",
                     "type": "array",
                     "items": {
-                        "type": "string"
+                        "$ref": "#/definitions/RelValue"
                     },
                     "minItems": 1
                 },
@@ -95,7 +95,7 @@
                             "description": "Defines the relationship of the sub-entity to its parent, per Web Linking (RFC5899).",
                             "type": "array",
                             "items": {
-                                "type": "string"
+                                "$ref": "#/definitions/RelValue"
                             },
                             "minItems": 1
                         }
@@ -250,7 +250,7 @@
                     "description": "Defines the relationship of the link to its entity, per Web Linking (RFC5988).",
                     "type": "array",
                     "items": {
-                        "type": "string"
+                        "$ref": "#/definitions/RelValue"
                     }
                 },
                 "href": {
@@ -263,6 +263,99 @@
                     "type": "string"
                 }
             }
+        },
+        "RelValue": {
+               "anyOf": [
+                {
+                    "type": "string",
+                    "format": "uri"
+                },
+                {
+                    "type": "string",
+                    "enum": [
+                        "about",
+                        "alternate",
+                        "appendix",
+                        "archives",
+                        "author",
+                        "blocked-by",
+                        "bookmark",
+                        "canonical",
+                        "chapter",
+                        "collection",
+                        "contents",
+                        "convertedFrom",
+                        "copyright",
+                        "create-form",
+                        "current",
+                        "derivedfrom",
+                        "describedby",
+                        "describes",
+                        "disclosure",
+                        "dns-prefetch",
+                        "duplicate",
+                        "edit",
+                        "edit-form",
+                        "edit-media",
+                        "enclosure",
+                        "first",
+                        "glossary",
+                        "help",
+                        "hosts",
+                        "hub",
+                        "icon",
+                        "index",
+                        "item",
+                        "last",
+                        "latest-version",
+                        "license",
+                        "lrdd",
+                        "memento",
+                        "monitor",
+                        "monitor-group",
+                        "next",
+                        "next-archive",
+                        "nofollow",
+                        "noreferrer",
+                        "original",
+                        "payment",
+                        "pingback",
+                        "preconnect",
+                        "predecessor-version",
+                        "prefetch",
+                        "preload",
+                        "prerender",
+                        "prev",
+                        "preview",
+                        "previous",
+                        "prev-archive",
+                        "privacy-policy",
+                        "profile",
+                        "related",
+                        "restconf",
+                        "replies",
+                        "search",
+                        "section",
+                        "self",
+                        "service",
+                        "start",
+                        "stylesheet",
+                        "subsection",
+                        "successor-version",
+                        "tag",
+                        "terms-of-service",
+                        "timegate",
+                        "timemap",
+                        "type",
+                        "up",
+                        "version-history",
+                        "via",
+                        "webmention",
+                        "working-copy",
+                        "working-copy-of"
+                    ]
+                }
+            ]
         }
     }
 }


### PR DESCRIPTION
Introduce validation constraints for the values of the `rel` property.

Without additional documentation, developers often do not know what values are allowed for the `rel` property. Furthermore, without an `enum` of allowed values, Siren containing invalid link relations is erroneously accepted as valid: Software like [JSON Schema Faker](http://json-schema-faker.js.org/) generates Siren containing invalid link relations without this patch.