### PR TITLE
Fields max min

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,14 @@ A collection of fields, expressed as an array of objects in JSON Siren such as `
 
 Fields represent controls inside of actions.  They may contain these attributes:
 
+####max
+
+A string or number describing the maximum value among the allowed range of values.  This property can only apply to a field with a linear or periodic domain.  Optional.
+
+####min
+
+A string or number describing the minimum value arong the allowed range of values.  This property can only apply to a field with a linear or periodic domain.  Optional.
+
 ####name
 
 A name describing the control.  Field names MUST be unique within the set of fields for an action. The behaviour of clients when parsing a Siren document that violates this constraint is undefined.  Required.

--- a/siren.schema.json
+++ b/siren.schema.json
@@ -157,6 +157,14 @@
                 "name"
             ],
             "properties": {
+                "max": {
+                    "description": "A string or number describing the maximum value among the allowed ranges of values for this field.",
+                    "type": [ "string", "number" ]
+                },
+                "min": {
+                    "description": "A string or number describing the minimum value among the allowed ranges of values for this field.",
+                    "type": [ "string", "number" ]
+                },
                 "name": {
                     "description": "A name describing the control. Field names MUST be unique within the set of fields for an action. The behaviour of clients when parsing a Siren document that violates this constraint is undefined.",
                     "type": "string"

--- a/siren.schema.json
+++ b/siren.schema.json
@@ -158,11 +158,11 @@
             ],
             "properties": {
                 "max": {
-                    "description": "A string or number describing the maximum value among the allowed ranges of values for this field.",
+                    "description": "A string or number describing the maximum value among the allowed ranges of values for this field. This property can only apply to a field with a linear or periodic domain.",
                     "type": [ "string", "number" ]
                 },
                 "min": {
-                    "description": "A string or number describing the minimum value among the allowed ranges of values for this field.",
+                    "description": "A string or number describing the minimum value among the allowed ranges of values for this field. This property can only apply to a field with a linear or periodic domain.",
                     "type": [ "string", "number" ]
                 },
                 "name": {


### PR DESCRIPTION
This adds `max` and `min` properties for fields that could have a range of allowed values.

`max` and `min` can be numbers or strings because field values can be numbers or strings.