### PR TITLE
Properties title

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,18 @@ The media type for JSON Siren is `application/vnd.siren+json`.
 {
   "class": [ "order" ],
   "properties": { 
-      "orderNumber": 42, 
-      "itemCount": 3,
-      "status": "pending"
+      "orderNumber": {
+        "title": "Order number",
+        "value": 42
+      },
+      "itemCount": {
+        "title:" "Items ordered",
+        "value": 3
+      },
+      "status": {
+        "title": "Order status",
+        "pending"
+      }
   },
   "entities": [
     { 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Describes the nature of an entity's content based on the current representation.
 
 ####`properties`
 
-A set of key-value pairs that describe the state of an entity.  In JSON Siren, this is an object such as `{ "name": "Kevin", "age": 30 }`.  Optional.
+A set of key-value pairs that describe the state of an entity.  In JSON Siren, this can be an object such as `{ "name": "Kevin", "age": 30 }`.  If the value is an object, it MUST contain a `title` property for a human-readable description and a `value` property for the actual value.  Optional.
 
 ####`entities`
 

--- a/siren.schema.json
+++ b/siren.schema.json
@@ -17,6 +17,12 @@
             "type": "string"
         },
         "properties": {
+            "additionalProperties": {
+                "anyOf": [
+                    { "$ref": "#/definitions/PropertyObject" },
+                    { "$ref": "#/definitions/PropertyValue" }
+                ]
+            },
             "description": "A set of key-value pairs that describe the state of an entity.",
             "type": "object"
         },
@@ -263,6 +269,27 @@
                     "type": "string"
                 }
             }
+        },
+        "PropertyObject": {
+            "description": "",
+            "type": "object",
+            "required": [
+                "title",
+                "value"
+            ],
+            "properties": {
+                "title": {
+                    "description": "Textual description of the property. Clients may use this as a label.",
+                    "type": "string"
+                },
+                "value": {
+                    "$ref": "#/definitions/PropertyValue"
+                }
+            }
+        },
+        "PropertyValue": {
+            "description": "A value assigned to the property.",
+            "type": [ "array", "boolean", "number", "string" ]
         }
     }
 }


### PR DESCRIPTION
This introduces human-readable titles for entity properties in a backwards-compatible way. Among other advantages, properties with objects as values would enable clients to display labels translated to the HTTP `Accept-Language`.