### PR TITLE
Fix inconsistent formatting of Fields section headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,11 +202,11 @@ The encoding type for the request.  When omitted and the `fields` attribute exis
 
 A collection of fields, expressed as an array of objects in JSON Siren such as `{ "fields" : [{ ... }] }`.  See Fields.  Optional.
 
-### Fields
+## Fields
 
 Fields represent controls inside of actions.  They may contain these attributes:
 
-#### name
+### `name`
 
 A name describing the control.  Field names MUST be unique within the set of fields for an action. The behaviour of clients when parsing a Siren document that violates this constraint is undefined.  Required.
 
@@ -214,7 +214,7 @@ A name describing the control.  Field names MUST be unique within the set of fie
 
 Describes aspects of the field based on the current representation.  Possible values are implementation-dependent and should be documented.  MUST be an array of strings.  Optional.
 
-#### type
+### `type`
 
 The input type of the field. This may include any of the following [input types](http://www.w3.org/TR/html5/single-page.html#the-input-element) specified in HTML5:
 
@@ -225,11 +225,11 @@ The input type of the field. This may include any of the following [input types]
 
 When missing, the default value is `text`.  Serialization of these fields will depend on the value of the action's `type` attribute. See [`type`](#type) under Actions, above. Optional.
 
-#### value
+### `value`
 
 A value assigned to the field.  Optional.
 
-#### title
+### `title`
 
 Textual annotation of a field.  Clients may use this as a label.  Optional.
 


### PR DESCRIPTION
Modify the format of the headers in the Fields section to be consistent with the other sections in the specification.