### PR TITLE
feat: Add $schema property

### DIFF
--- a/siren.schema.json
+++ b/siren.schema.json
@@ -5,6 +5,19 @@
     "description": "An Entity is a URI-addressable resource that has properties and actions associated with it. It may contain sub-entities and navigational links.",
     "type": "object",
     "properties": {
+        "$schema": {
+            "title": "JSON Schema to use",
+            "description": "Can be a local schema or a remote one (ie from http://schemastore.org)",
+            "oneOf": [
+                {
+                    "type": "string",
+                    "format": "uri"
+                },
+                {
+                    "type": "string"
+                }
+            ]
+        },
         "class": {
             "description": "Describes the nature of an entity's content based on the current representation. Possible values are implementation-dependent and should be documented.",
             "type": "array",


### PR DESCRIPTION
VS Code supports [code completion for JSON files](https://code.visualstudio.com/docs/languages/json) based on [JSON Schema](https://json-schema.org/specification.html).

Code completion in VS Code picks up a schema for any JSON file if the schema is
specified as `"$schema": "<URL to schema>"`.

It automatically picks up [certain JSON Schemas](https://code.visualstudio.com/docs/languages/json#_json-schemas-and-settings) by file name (ie: `package.json`) and you can configure your own associations via (workspace) `settings.json` like this:

```json
"json.schemas": [
  {
    "fileMatch": [
      "resume.json"
    ],
    "url": "http://json.schemastore.org/resume"
  }
]
```

Alternatively VS Code supports the `$schema` key in JSON files itself.

So in a `resume.json` we could add the [JSON Resume schema](http://json.schemastore.org/resume) to get code completion without touching the VS Code settings:

```json
{
  "$schema": "http://json.schemastore.org/resume",
}
```

So please JSON Schema authors allow the specification of the schema in your JSON Schema like this:

```json
{
  "properties": {
    "$schema": {
      "title": "JSON Schema to use",
      "description": "Can be a local schema or a remote one (ie from http://schemastore.org)",
      "oneOf": [
        {
          "type": "string",
          "format": "uri"
        },
        {
          "type": "string"
        }
      ]
    },
  }
}
```

[XML](https://www.w3.org/TR/2008/REC-xml-20081126/) had a similar feature where you could specify an [XSD](https://www.w3.org/TR/xmlschema-0/) in the XML pre-processing tags to validate the syntax and data (to some extent) of the XML.